### PR TITLE
TypeError: Object.keys called on non-object

### DIFF
--- a/Collection.coffee
+++ b/Collection.coffee
@@ -195,7 +195,7 @@ define [
 
       collectionVersion = global.config.static.collection
 
-      tagz = _.keys(options.tags).join('_')
+      tagz = if options.tags? then _.keys(options.tags).join('_') else ''
 
       [
         collectionVersion


### PR DESCRIPTION
Если вызвать repo.createCollection({}) то падает с ошибкой
TypeError: Object.keys called on non-object
