### PR TITLE
ModelRepo._buildApiRequestUrl добавляет слэш в конец пути

### DIFF
--- a/ModelRepo.coffee
+++ b/ModelRepo.coffee
@@ -434,7 +434,7 @@ define [
         urlParams.push("_fields=id")
       urlParams.push("_calc=#{ calcFields.join(',') }") if calcFields.length > 0
 
-      @restResource + (if params.accessPoint? then ('/' + params.accessPoint) else '') + (if params.id then '/' + params.id + '/?'  else '/?') + urlParams.join('&')
+      @restResource + (if params.accessPoint? then ('/' + params.accessPoint) else '') + (if params.id then '/' + params.id + '?'  else '?') + urlParams.join('&')
 
 
     delete: (model) ->


### PR DESCRIPTION
Можно ли убрать слэш, добавляемый в url перед get-параметрами?
Чтобы не модифицировать принимаемый адрес
